### PR TITLE
Replace Javadoc with Dokka

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ web_repo: https://github.com/SpineEventEngine/web
 dart_repo: https://github.com/SpineEventEngine/dart
 
 base_api_doc: https://spine.io/base/reference
-core_api_doc: https://spine.io/core-java/reference
+core_api_doc: https://spine.io/core-java/dokka-reference
 web_api_doc: https://spine.io/web/reference
 js_api_doc: https://spine.io/web/reference/client-js
 dart_api_doc: https://spine.io/dart/reference

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ dart_repo: https://github.com/SpineEventEngine/dart
 
 base_api_doc: https://spine.io/base/dokka-reference
 core_api_doc: https://spine.io/core-java/dokka-reference
-web_api_doc: https://spine.io/web/reference
+web_api_doc: https://spine.io/web/dokka-reference
 js_api_doc: https://spine.io/web/reference/client-js
 dart_api_doc: https://spine.io/dart/reference
 

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ core_java_repo: https://github.com/SpineEventEngine/core-java
 web_repo: https://github.com/SpineEventEngine/web
 dart_repo: https://github.com/SpineEventEngine/dart
 
-base_api_doc: https://spine.io/base/reference
+base_api_doc: https://spine.io/base/dokka-reference
 core_api_doc: https://spine.io/core-java/dokka-reference
 web_api_doc: https://spine.io/web/reference
 js_api_doc: https://spine.io/web/reference/client-js

--- a/docs/client-libs/index.md
+++ b/docs/client-libs/index.md
@@ -6,5 +6,5 @@ layout: docs
 ---
 # Java Client Library
 
- * [Reference documentation]({{site.core_api_doc}}/client/index.html)
+ * [Reference documentation]({{site.core_api_doc}}/client)
  * [Source code]({{site.core_java_repo}}/tree/master/client)

--- a/docs/guides/gradle.md
+++ b/docs/guides/gradle.md
@@ -161,8 +161,8 @@ Spine Model Compiler is a Gradle plugin which executes all the code generation r
 Gradle tasks as well as the `modelCompiler { }` extension, which allows you to configure those
 tasks.
 
-See the API reference for the list of the [declared tasks]({{site.base_api_doc}}/plugin-base/io/spine/tools/gradle/ModelCompilerTaskName.html)
-and the [codegen configuration options]({{site.base_api_doc}}/model-compiler/io/spine/tools/gradle/compiler/Extension.html)
+See the API reference for the list of the [declared tasks]({{site.base_api_doc}}/plugin-base/plugin-base/io.spine.tools.gradle/-model-compiler-task-name)
+and the [codegen configuration options]({{site.base_api_doc}}/model-compiler/model-compiler/io.spine.tools.gradle.compiler/-extension)
 
 ### ProtoJS Plugin
 
@@ -171,5 +171,5 @@ The plugin adds the `generateJsonParsers` task, which appends generated JS files
 Protobuf messages out of plain JS objects.
 
 The plugin also provides the `protoJs { }` extension, which allows you to configure JS code
-generation. See the [API reference]({{site.base_api_doc}}/proto-js-plugin/io/spine/js/gradle/Extension.html)
+generation. See the [API reference]({{site.base_api_doc}}/proto-js-plugin/proto-js-plugin/io.spine.js.gradle/-extension)
 for more info.

--- a/docs/guides/gradle.md
+++ b/docs/guides/gradle.md
@@ -142,7 +142,7 @@ language and responsibility boundaries.
 
 If your server should be deployed as a whole, use a single `web-server` for all the contexts. If you
 would like to deploy different contexts separately, declare a specific `web-server` subprojects
-for each of those contexts. See the [API reference]({{site.core_api_doc}}/server/io/spine/server/ServerEnvironment.html#use-io.spine.server.transport.TransportFactory-io.spine.base.EnvironmentType-)
+for each of those contexts. See the [API reference]({{site.core_api_doc}}/server/server/io.spine.server/-server-environment)
 for the instructions on integrating Bounded Contexts. Also, see [this guide]({{site.baseurl}}/docs/guides/integration)
 on the principles of integrating separate Bounded Contexts and third-party systems in Spine.
 

--- a/docs/guides/gradle.md
+++ b/docs/guides/gradle.md
@@ -142,8 +142,7 @@ language and responsibility boundaries.
 
 If your server should be deployed as a whole, use a single `web-server` for all the contexts. If you
 would like to deploy different contexts separately, declare a specific `web-server` subprojects
-for each of those contexts. See the [API reference]({{site.core_api_doc}}/server/server/io.spine.server/-server-environment)
-for the instructions on integrating Bounded Contexts. Also, see [this guide]({{site.baseurl}}/docs/guides/integration)
+for each of those contexts. See [this guide]({{site.baseurl}}/docs/guides/integration)
 on the principles of integrating separate Bounded Contexts and third-party systems in Spine.
 
 ## Verbose configuration

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -143,7 +143,7 @@ The event producer obtains cached historical events, matches them to the receive
 and sends them to the client. The **Takeoffs and Landings** system implements 
 an&nbsp;[event consumer](https://github.com/spine-examples/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/supplies/SuppliesEventConsumer.java)
 which constructs a subscription and maintains it as long as the system needs to receive more events.
-The consumer broadcasts the received Events via an instance of [`ThirdPartyContext`]({{site.core_api_doc}}/server/io/spine/server/integration/ThirdPartyContext.html):
+The consumer broadcasts the received Events via an instance of [`ThirdPartyContext`]({{site.core_api_doc}}/server/server/io.spine.server.integration/-third-party-context):
 
 <embed-code file="examples/airport/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/supplies/SuppliesEventConsumer.java" 
             fragment="onNext"></embed-code>
@@ -302,7 +302,7 @@ which performs all the technical work of obtaining and validating data, and a [P
 for the [Boarding process](https://github.com/spine-examples/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java).
 The **Security Checks** API provides data for each passenger independently. The client polls
 the data and publishes many intermediate `PassengerBoarded` or `PassengerDeniedBoarding` external
-events via [`ThirdPartyContext`]({{site.core_api_doc}}/server/io/spine/server/integration/ThirdPartyContext.html):
+events via [`ThirdPartyContext`]({{site.core_api_doc}}/server/server/io.spine.server.integration/-third-party-context):
 
 <embed-code file="examples/airport/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/PassengerClient.java" 
             fragment="Fetch passengers"></embed-code>

--- a/docs/introduction/concepts.md
+++ b/docs/introduction/concepts.md
@@ -106,7 +106,7 @@ generates events in response to changes in the domain.
 
 <p class="note">In some cases, Event Reactor may ignore the event, returning `Nothing`.
     It usually happens when a method returns one of the
-    [`Either`]({{site.core_api_doc}}/server/index.html) types, with `Nothing` as
+    [`Either`]({{site.core_api_doc}}/server/server/io.spine.server.tuple/-either) types, with `Nothing` as
     one of the possible options: `EitherOf2<TaskReAssigned, Nothing>`.</p>
 
 ## Value Objects
@@ -181,9 +181,9 @@ Repository encapsulates storage, retrieval, and search of Entities as if it were
 a collection of objects. It isolates domain objects from the details of the database access code. 
 
 The applications you develop using Spine usually have the following types of repositories:
-* [`AggregateRepository`]({{site.core_api_doc}}/server/io/spine/server/aggregate/AggregateRepository.html),
-* [`ProcessManagerRepository`]({{site.core_api_doc}}/server/io/spine/server/procman/ProcessManagerRepository.html),
-* [`ProjectionRepository`]({{site.core_api_doc}}/server/io/spine/server/projection/ProjectionRepository.html).
+* [`AggregateRepository`]({{site.core_api_doc}}/server/server/io.spine.server.aggregate/-aggregate-repository),
+* [`ProcessManagerRepository`]({{site.core_api_doc}}/server/server/io.spine.server.procman/-process-manager),
+* [`ProjectionRepository`]({{site.core_api_doc}}/server/server/io.spine.server.projection/-projection-repository).
 
 ### Snapshot
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -215,7 +215,7 @@ assertEntity.hasStateThat()
 ### Configuring Server Environment
 
 For information on configuring server environment of a Spine-based application, please 
-see the reference documentation of the [`ServerEnvironment`]({{site.core_api_doc}}/server/io/spine/server/ServerEnvironment.html)
+see the reference documentation of the [`ServerEnvironment`]({{site.core_api_doc}}/server/server/io.spine.server/-server-environment)
 class.
 
 ### Assembling Application

--- a/docs/introduction/naming-conventions.md
+++ b/docs/introduction/naming-conventions.md
@@ -286,7 +286,7 @@ which seem hierarchical for convenience. When it comes to placing source code fi
 in a project, there is usually nesting formed by the directories in a file system.
 
 Spine framework uses this notion of “nesting” for marking multiple packages of a server-side code 
-[belonging to a Bounded Context]({{site.core_api_doc}}/core/io/spine/core/BoundedContext.html)
+[belonging to a Bounded Context]({{site.core_api_doc}}/core/core/io.spine.core/-bounded-context)
 easier. But this is a convenience feature, not a requirement.
    
 Please see our recommendations for organizing generated and handcrafted code in sections below.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,9 +8,9 @@ layout: docs
 
 ## Java
 
-- [Server]({{site.core_api_doc}}/server/index.html)
+- [Server]({{site.core_api_doc}}/server)
 
-- [Client]({{site.core_api_doc}}/client/index.html)
+- [Client]({{site.core_api_doc}}/client)
 
 - [Spine Web API]({{site.web_api_doc}}/web/index.html).
 This reference defines the API for communicating with a Spine-based backend using web requests.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,10 +12,10 @@ layout: docs
 
 - [Client]({{site.core_api_doc}}/client)
 
-- [Spine Web API]({{site.web_api_doc}}/web/index.html).
+- [Spine Web API]({{site.web_api_doc}}/web).
 This reference defines the API for communicating with a Spine-based backend using web requests.
 
-- [Web API implementation on Firebase]({{site.web_api_doc}}/firebase-web/index.html).
+- [Web API implementation on Firebase]({{site.web_api_doc}}/firebase-web).
 This reference is on the implementation of the Spine Web API using the Firebase Realtime Database
 to deliver data to web clients.
 


### PR DESCRIPTION
This PR replaces links to the Javadoc documentation with links to the Dokka documentation.