### PR TITLE
Revert to Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source "https://rubygems.org"
 gem "jekyll"
 gem "github-pages"
 
-# Ruby 3.2 has some issues when dealing with `4.0.3`; so bumping the version to `4.0.4`.
-gem "liquid", "4.0.4"
-
-# Ruby 3.x does not include this gem anymore, so installing manually.
-gem "webrick"
-
 # kramdown v2 ships without the gfm parser by default. If you're using
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,6 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
-    webrick (1.8.1)
     zeitwerk (2.5.3)
 
 PLATFORMS
@@ -288,8 +287,6 @@ DEPENDENCIES
   github-pages
   jekyll
   kramdown-parser-gfm
-  liquid (= 4.0.4)
-  webrick
 
 BUNDLED WITH
    2.4.13

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -19,7 +19,7 @@ layout: docs
     <li><a target="_blank" href="https://github.com/spine-examples/airport">Airport</a>
      — integrating a third-party systems using a Bounded Context.
        This example accompanies the <a href="{{site.baseurl}}/docs/guides/integration">“Integration with a Third Party”</a> guide.</li>
-    <li><a target="_blank" href="https://github.com/spine-examples/todo-list">ToDo List</a>
+    <li><a target="_blank" href="https://github.com/spine-examples/todo-list">To-Do List</a>
      — a simple task management system with multiple client applications. If&nbsp;you&nbsp;want&nbsp;to see
       a bigger picture of a Spine-based solution, have a look at this example.</li>
 </ul>


### PR DESCRIPTION
As GH Pages only supports Ruby 2.7, this PR reverts the changes previously made to support Ruby 3.2 runtime.

Also, a small typo was addressed.