### PR TITLE
Update the links to API docs of the renamed repos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ core_java_repo: https://github.com/SpineEventEngine/core-java
 web_repo: https://github.com/SpineEventEngine/web
 dart_repo: https://github.com/SpineEventEngine/dart
 
-base_api_doc: https://spine.io/base/dokka-reference
-core_api_doc: https://spine.io/core-java/dokka-reference
+base_api_doc: https://spine.io/base-libraries/dokka-reference
+core_api_doc: https://spine.io/core-jvm/dokka-reference
 web_api_doc: https://spine.io/web/dokka-reference
 js_api_doc: https://spine.io/web/reference/client-js
 dart_api_doc: https://spine.io/dart/reference


### PR DESCRIPTION
This changeset addresses the recent renaming of the repositories in this organization, making their API docs linked through the [spine.io](https://spine.io) website.