### PR TITLE
Rework the sidenav and TOC columns

### DIFF
--- a/_hugo-site/assets/scss/docs/_layout.scss
+++ b/_hugo-site/assets/scss/docs/_layout.scss
@@ -29,5 +29,9 @@
     .sticky-col {
       top: 0;
     }
+
+    .content-col {
+      padding-bottom: 20px;
+    }
   }
 }

--- a/_hugo-theme/assets/js/docs/element-max-height.js
+++ b/_hugo-theme/assets/js/docs/element-max-height.js
@@ -34,6 +34,8 @@
  */
 export function setElementMaxHeight() {
     const $element = $('.set-max-height');
+    const $navbar = $('#header');
+    const navbarHeight = $navbar.innerHeight();
     let scrollTop = 0;
 
     if (!$element) return;
@@ -87,7 +89,7 @@ export function setElementMaxHeight() {
      * @return {number} the top position of the element
      */
     function getTopOffset($element) {
-        const stickyTop = parseInt($element.css('top'), 10) || 0;
+        const stickyTop = parseInt($element.css('top'), 10) || navbarHeight || 0;
         const isSticky = $element[0].getBoundingClientRect().top <= stickyTop;
         let topPosition;
 

--- a/_hugo-theme/assets/js/docs/element-max-height.js
+++ b/_hugo-theme/assets/js/docs/element-max-height.js
@@ -34,26 +34,26 @@
  */
 export function setElementMaxHeight() {
     const $element = $('.set-max-height');
-    const $footer = $('.footer');
-    const headerHeight = $('#header').length ? $('#header').outerHeight() : 0;
-    const footerTopPosition = $footer.length ? $footer.position().top : 0;
+    let scrollTop = 0;
 
-    if ($element.length) {
+    if (!$element) return;
+
+    updateMaxHeight();
+
+    $(window).on('load resize scroll', function () {
+        scrollTop = $(window).scrollTop();
         updateMaxHeight();
-
-        $(window).on('resize scroll', function () {
-            updateMaxHeight();
-        });
-    }
+    });
 
     /**
      * Sets the `max-height` value to the element
      * to be sure that it always fits on the page.
      */
     function updateMaxHeight() {
-        const maxHeight = calculateMaxHeight();
-
         $element.each(function() {
+            const $this = $(this);
+            const maxHeight = calculateMaxHeight($this);
+
             $(this).css({
                 'overflow': 'auto',
                 'max-height': maxHeight
@@ -67,22 +67,36 @@ export function setElementMaxHeight() {
      *
      * @return {number} maxHeight the value of the maximum possible height
      */
-    function calculateMaxHeight() {
+    function calculateMaxHeight($element) {
         const windowHeight = $(window).height();
-        const scrollTop = $(window).scrollTop();
-        const elementTopMargin = 24;
+        const elementTopPosition = getTopOffset($element);
         const elementBottomMargin = 20;
-        const elementTopPosition = headerHeight + elementTopMargin;
         const maxHeight = windowHeight - elementTopPosition - elementBottomMargin;
 
-        if ($footer.length) {
-            const isFooterVisible = windowHeight + scrollTop > footerTopPosition;
+        return maxHeight;
+    }
 
-            if (isFooterVisible) {
-                return footerTopPosition - scrollTop - elementTopPosition - elementBottomMargin;
-            }
+    /**
+     * Returns the provided element top position relative to the window.
+     *
+     * <p>If the element is sticky, returns the CSS `top` value, otherwise
+     * calculates the top position. It is useful when the hero section
+     * is present on the page.
+     *
+     * @param $element the element whose position needs to be calculated
+     * @return {number} the top position of the element
+     */
+    function getTopOffset($element) {
+        const stickyTop = parseInt($element.css('top'), 10) || 0;
+        const isSticky = $element[0].getBoundingClientRect().top <= stickyTop;
+        let topPosition;
+
+        if (isSticky) {
+            topPosition = stickyTop;
+        } else {
+            topPosition = $element.offset().top - scrollTop;
         }
 
-        return maxHeight;
+        return topPosition;
     }
 }

--- a/_hugo-theme/assets/js/docs/element-max-height.js
+++ b/_hugo-theme/assets/js/docs/element-max-height.js
@@ -67,6 +67,7 @@ export function setElementMaxHeight() {
      * Calculates the possible element `max-height` based on the window
      * and navigation heights.
      *
+     * @param $element the element whose max-height needs to be calculated
      * @return {number} maxHeight the value of the maximum possible height
      */
     function calculateMaxHeight($element) {

--- a/_hugo-theme/assets/scss/docs/modules/_article-container.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_article-container.scss
@@ -28,7 +28,6 @@ $article-border-color: #e6ecf1;
 $article-container-border: 1px solid $article-border-color;
 $article-side-padding: 56px;
 $article-container-padding: 32px $article-side-padding 40px;
-$article-container-margin-bottom: 32px;
 $article-container-border-radius: 3px;
 $article-container-min-height: 460px;
 
@@ -39,7 +38,6 @@ $article-container-min-height: 460px;
   border: $article-container-border;
   border-radius: $article-container-border-radius;
   padding: $article-container-padding;
-  margin-bottom: $article-container-margin-bottom;
   min-width: 0; // Fixes a bug when `pre` code breaks flex element.
   min-height: $article-container-min-height;
 

--- a/_hugo-theme/assets/scss/docs/modules/_interactive-toc.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_interactive-toc.scss
@@ -30,6 +30,7 @@
 */
 
 .interactive-toc {
+  $toc-top-offset: 24px;
   $toc-item-font-size: 12px;
   $toc-item-color: $gray-700;
   $toc-item-line-height: 1.5;
@@ -38,6 +39,8 @@
   $toc-indicator-width: 1px;
   $toc-indicator-line-color: rgba(0, 0, 0, .12);
   $toc-indicator-color: $main-brand-color;
+
+  padding-top: $toc-top-offset + 8px;
 
   #TableOfContents {
     margin-bottom: 0;

--- a/_hugo-theme/assets/scss/docs/modules/_layout.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_layout.scss
@@ -65,17 +65,9 @@ $doc-sidenav-background: $gray-100;
       padding: 0;
     }
 
-    $col-top-padding: 24px;
-    $col-top-extra: 8px;
-
     .doc-sidenav-col,
     .toc-col {
-      padding: $col-top-padding 0 24px;
-    }
-
-    // Aligns TOC column with the sidenav.
-    .toc-col {
-      padding-top: $col-top-padding + $col-top-extra;
+      padding: 0 0 24px;
     }
 
     .content-col {

--- a/_hugo-theme/assets/scss/docs/modules/_sidenav.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_sidenav.scss
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+$sidenav-top-offset: 24px;
 $sidenav-link-top-level-font-size: 14px;
 $sidenav-link-font-size: 13px;
 $sidenav-link-color: rgba(0, 0, 0, .54);
@@ -41,6 +42,7 @@ $sidenav-holder-padding: 32px 24px 32px 16px;
 $sidenav-title-left-padding: 22px;
 
 .doc-sidenav {
+  padding-top: $sidenav-top-offset;
   margin-left: -$sidenav-first-level-left-padding;
   width: $sticky-docs-sidenav-width;
   list-style: none;


### PR DESCRIPTION
This PR reworks the sticky sidenav and TOC columns and now they start at the top without any additional offsets. Also, the `max-width` calculation has been improved.