### PR TITLE
Clean up styles

### DIFF
--- a/_hugo-site/assets/scss/docs/_home.scss
+++ b/_hugo-site/assets/scss/docs/_home.scss
@@ -34,7 +34,7 @@
     max-width: 760px;
     padding: 48px 56px;
 
-    @media (max-width: $phone-medium) {
+    @include breakpoint(md-phone) {
       padding: 24px;
     }
 
@@ -46,7 +46,7 @@
       margin-bottom: 32px;
       padding-top: 16px;
 
-      @media (max-width: $phone-medium) {
+      @include breakpoint(md-phone) {
         font-size: $font-size--xl;
       }
     }

--- a/_hugo-site/config/_default/hugo.toml
+++ b/_hugo-site/config/_default/hugo.toml
@@ -1,6 +1,7 @@
 baseURL = 'https://spine.io/'
 languageCode = 'en-us'
 title = 'Documentation preview'
+disableKinds = ['taxonomy', 'term']
 
 [module]
   # First theme has higher priority than later ones.

--- a/_hugo-theme/assets/js/docs/code-theme.js
+++ b/_hugo-theme/assets/js/docs/code-theme.js
@@ -65,7 +65,8 @@ export function initCodeTheme() {
         $codeBlock.each(function () {
             const icon = $(`<i class="${toggleClass.toggle}"
                                aria-label="Change code theme"
-                               title="Change code theme"></i>`)
+                               title="Change code theme"></i>`);
+            icon.tooltip('enable');
             $(this).append(icon);
         });
     }

--- a/_hugo-theme/assets/scss/docs-common.scss
+++ b/_hugo-theme/assets/scss/docs-common.scss
@@ -32,4 +32,5 @@
 @import "docs-common/layout";
 @import "docs-common/code";
 @import "docs-common/snackbar";
+@import "docs-common/tooltip";
 @import "docs-common/anchor-icon";

--- a/_hugo-theme/assets/scss/docs-common/_config.scss
+++ b/_hugo-theme/assets/scss/docs-common/_config.scss
@@ -34,18 +34,6 @@ $article-line-height: 1.74;
 // General dimensions and spacing
 $header-height              : 68px;
 
-// Responsive
-$phone-small                : 320px;
-$phone-medium               : 480px;
-$phone-large                : 512px;
-$phone-xlarge               : 640px;
-$tablet                     : 768px;
-$tablet-large               : 991px;
-$desktop-small              : 1024px;
-$desktop-medium             : 1280px;
-$desktop-large              : 1440px;
-$mobile                     : $desktop-small;
-
 // Z-index
 // Usage: z-index: map_get($z-index, 'color-selector');
 $z-index: (

--- a/_hugo-theme/assets/scss/docs-common/_config.scss
+++ b/_hugo-theme/assets/scss/docs-common/_config.scss
@@ -32,7 +32,7 @@ $doc-sidenav-mobile-breakpoint: 880px;
 $article-line-height: 1.74;
 
 // General dimensions and spacing
-$header-height              : 68px;
+$header-height: 68px;
 
 // Z-index
 // Usage: z-index: map_get($z-index, 'color-selector');

--- a/_hugo-theme/assets/scss/docs-common/_layout.scss
+++ b/_hugo-theme/assets/scss/docs-common/_layout.scss
@@ -64,17 +64,17 @@ $layout-padding-phone: 20px;
 .content-holder {
   max-width: $layout-max-width;
 
-  @media(max-width: $desktop-medium) {
+  @include breakpoint(md-desktop) {
     padding-right: $layout-padding-medium;
     padding-left: $layout-padding-medium;
   }
 
-  @media(max-width: $tablet) {
+  @include breakpoint(tablet) {
     padding-right: $layout-padding-tablet;
     padding-left: $layout-padding-tablet;
   }
 
-  @media(max-width: $phone-medium) {
+  @include breakpoint(md-phone) {
     padding-right: $layout-padding-phone;
     padding-left: $layout-padding-phone;
   }

--- a/_hugo-theme/assets/scss/docs-common/_mixins.scss
+++ b/_hugo-theme/assets/scss/docs-common/_mixins.scss
@@ -66,3 +66,19 @@ $breakpoints: (
     }
   }
 }
+
+// Usage: `@include breakpoint-min-and-max(md-tablet, desktop) {}`
+@mixin breakpoint-min-and-max($minWidth, $maxWidth) {
+  @if map-has-key($breakpoints, $minWidth) and map-has-key($breakpoints, $maxWidth) {
+    $minValue: map-get($breakpoints, $minWidth);
+    $maxValue: map-get($breakpoints, $maxWidth);
+
+    @media (min-width: $minValue + 1) and (max-width: $maxValue) {
+      @content;
+    }
+  } @else {
+    @media (min-width: $minWidth + 1) and (max-width: $maxWidth) {
+      @content;
+    }
+  }
+}

--- a/_hugo-theme/assets/scss/docs-common/_mixins.scss
+++ b/_hugo-theme/assets/scss/docs-common/_mixins.scss
@@ -24,8 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*TODO:2025-11-27:julia.evseeva: Add the list with breakpoints here
-   and remove from the `config`. */
 $breakpoints: (
         sm-phone:     320px,
         md-phone:     480px,

--- a/_hugo-theme/assets/scss/docs-common/_tooltip.scss
+++ b/_hugo-theme/assets/scss/docs-common/_tooltip.scss
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import 'bootstrap/js/dist/collapse';
-import 'bootstrap/js/dist/dropdown';
-import 'bootstrap/js/dist/tooltip';
+/* Overrides styles of the Bootstrap tooltip. */
+
+.tooltip {
+  --bs-tooltip-padding-y: .5rem;
+  --bs-tooltip-padding-x: .7rem;
+  --bs-tooltip-bg: #232526;
+  --bs-tooltip-opacity: .87;
+  --bs-tooltip-font-size: 12px;
+  --bs-tooltip-border-radius: 5px;
+
+  line-height: 1.4;
+}

--- a/_hugo-theme/assets/scss/docs/base/_mixins.scss
+++ b/_hugo-theme/assets/scss/docs/base/_mixins.scss
@@ -1,37 +1,51 @@
-// Usage: @include transition(all .3s ease-in-out);
-@mixin transition($args...) {
-  -webkit-transition: $args;
-  -moz-transition: $args;
-  -ms-transition: $args;
-  -o-transition: $args;
-  transition: $args;
-}
+/*!
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-// Usage: @include box-shadow(0 10px 20px 0 rgba(black, .12));
-@mixin box-shadow($args...) {
-  -webkit-box-shadow: $args;
-  -moz-box-shadow: $args;
-  -o-box-shadow: $args;
-  box-shadow: $args;
-}
-
+/*
+  The close icon.
+ */
 @mixin close-icon {
   display: inline-block;
   width: $icon-size--s;
   height: $icon-size--s;
-  background: url('https://spine.io/img/x-black.svg') no-repeat center/cover;
+  background: url('img/icons/close.svg') no-repeat center/cover;
   opacity: .26;
-  @include transition(all .3s ease-in-out);
+  transition: all .3s ease-in-out;
 }
 
-// Ordered and unordered list styles.
-// Usage: `@include list();`
+/*
+  Ordered and unordered list styles.
+  Usage: `@include list();`
+ */
 @mixin list($item-line-height: 1.6) {
   ol, ul {
     margin: 0 0 32px 0;
     line-height: $item-line-height;
 
-    @media (max-width: $tablet) {
+    @include breakpoint(tablet) {
       margin-bottom: 24px;
     }
 

--- a/_hugo-theme/assets/scss/docs/modules/_article-container.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_article-container.scss
@@ -41,7 +41,7 @@ $article-container-min-height: 460px;
   min-width: 0; // Fixes a bug when `pre` code breaks flex element.
   min-height: $article-container-min-height;
 
-  @media (max-width: $phone-xlarge) {
+  @include breakpoint(lg-phone) {
     padding: 0;
     border: none;
   }
@@ -50,10 +50,11 @@ $article-container-min-height: 460px;
   // Extends styles provided in `scss/docs-common/code/_index.scss`.
   --code-block-padding: #{$article-side-padding};
 
-  @media (max-width: $phone-xlarge) {
+  @include breakpoint(lg-phone) {
     --code-block-padding: 32px;
   }
-  @media (max-width: $phone-medium) {
+
+  @include breakpoint(md-phone) {
     --code-block-padding: 20px;
   }
 

--- a/_hugo-theme/assets/scss/docs/modules/_article-text.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_article-text.scss
@@ -82,11 +82,11 @@
     line-height: $article-line-height;
     text-align: justify;
 
-    @media (max-width: $tablet) {
+    @include breakpoint(tablet) {
       font-size: $font-size--s;
     }
 
-    @media (max-width: $phone-medium) {
+    @include breakpoint(md-phone) {
       text-align: left;
     }
   }
@@ -147,7 +147,7 @@
     margin: 0 auto;
     display: block;
 
-    @media (max-width: $phone-xlarge) {
+    @include breakpoint(lg-phone) {
       max-width: 100%;
     }
   }
@@ -199,7 +199,7 @@
     padding-top: 16px;
     margin-bottom: 32px;
 
-    @media (max-width: $phone-xlarge) {
+    @include breakpoint(lg-phone) {
       margin-bottom: 16px;
     }
   }

--- a/_hugo-theme/assets/scss/docs/modules/_book-card.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_book-card.scss
@@ -26,10 +26,10 @@
 
 .book-card {
   $book-mobile-breakpoint: xmd-phone;
-  
+
   position: relative;
   padding-bottom: 32px;
-  
+
   @include breakpoint-min($book-mobile-breakpoint) {
     min-height: 240px;
     padding-bottom: 48px;

--- a/_hugo-theme/assets/scss/docs/modules/_book-card.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_book-card.scss
@@ -25,10 +25,12 @@
  */
 
 .book-card {
+  $book-mobile-breakpoint: xmd-phone;
+  
   position: relative;
   padding-bottom: 32px;
-
-  @media (min-width: $phone-large) {
+  
+  @include breakpoint-min($book-mobile-breakpoint) {
     min-height: 240px;
     padding-bottom: 48px;
   }
@@ -59,7 +61,7 @@
       transform: skewX(40deg);
     }
 
-    @media (max-width: $phone-large) {
+    @include breakpoint($book-mobile-breakpoint) {
       width: $book-size-mobile;
     }
 
@@ -71,7 +73,7 @@
   .book-info {
     padding-left: $book-size + 32px;
 
-    @media (max-width: $phone-large) {
+    @include breakpoint($book-mobile-breakpoint) {
       padding-left: $book-size-mobile + 20px;
     }
 
@@ -106,7 +108,7 @@
     }
 
     .description {
-      @media (max-width: $tablet) {
+      @include breakpoint(tablet) {
         text-align: left;
       }
     }
@@ -115,7 +117,7 @@
       padding-top: 4px;
       margin-bottom: 6px;
 
-      @media (max-width: $phone-large) {
+      @include breakpoint($book-mobile-breakpoint) {
         padding-top: 0;
       }
     }

--- a/_hugo-theme/assets/scss/docs/modules/_docs-category-card.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_docs-category-card.scss
@@ -30,7 +30,7 @@
   gap: 24px;
   margin-bottom: 24px;
 
-  @media (max-width: $phone-xlarge) {
+  @include breakpoint(lg-phone) {
     grid-template-columns: 1fr;
   }
 

--- a/_hugo-theme/assets/scss/docs/modules/_layout.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_layout.scss
@@ -32,7 +32,7 @@ $doc-sidenav-background: $gray-100;
 .docs {
   background-color: $body-light-gray-color;
 
-  @media (max-width: $phone-xlarge) {
+  @include breakpoint(lg-phone) {
     background-color: white;
   }
 
@@ -61,7 +61,7 @@ $doc-sidenav-background: $gray-100;
   .content-columns {
     padding: 0 15px;
 
-    @media (max-width: $doc-sidenav-mobile-breakpoint) {
+    @include breakpoint($doc-sidenav-mobile-breakpoint) {
       padding: 0;
     }
 

--- a/_hugo-theme/assets/scss/docs/modules/_person-card.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_person-card.scss
@@ -38,7 +38,7 @@
     height: $avatar-size;
     border-radius: 50%;
 
-    @media (max-width: $phone-large) {
+    @include breakpoint(xmd-phone) {
       width: $avatar-size-mobile;
       height: $avatar-size-mobile;
     }
@@ -47,7 +47,7 @@
   .person-info {
     padding-left: $avatar-size + 20px;
 
-    @media (max-width: $phone-large) {
+    @include breakpoint(xmd-phone) {
       padding-left: $avatar-size-mobile + 20px;
     }
 

--- a/_hugo-theme/assets/scss/docs/modules/_sidenav.scss
+++ b/_hugo-theme/assets/scss/docs/modules/_sidenav.scss
@@ -47,7 +47,7 @@ $sidenav-title-left-padding: 22px;
   width: $sticky-docs-sidenav-width;
   list-style: none;
 
-  @media(max-width: $tablet-large){
+  @include breakpoint(sm-desktop) {
     margin: 0;
     width: 100%;
     max-height: none !important; // Unsets calculated max-height for the sticky element on mobile.
@@ -68,7 +68,7 @@ $sidenav-title-left-padding: 22px;
     font-weight: 400;
     cursor: pointer;
 
-    @media (max-width: $tablet-large) {
+    @include breakpoint(sm-desktop) {
       padding: 12px $sidenav-first-level-left-padding;
     }
 
@@ -89,7 +89,7 @@ $sidenav-title-left-padding: 22px;
         transform: rotate(45deg);
         transition: all .3s ease-in-out;
 
-        @media (max-width: $tablet-large) {
+        @include breakpoint(sm-desktop) {
           top: 18px;
         }
       }
@@ -103,7 +103,7 @@ $sidenav-title-left-padding: 22px;
           top: 15px;
           transform: rotate(-45deg);
 
-          @media (max-width: $tablet-large) {
+          @include breakpoint(sm-desktop) {
             top: 19px;
           }
         }
@@ -173,7 +173,7 @@ $sidenav-title-left-padding: 22px;
 .mobile-sidenav-header {
   display: none;
 
-  @media(max-width: $doc-sidenav-mobile-breakpoint) {
+  @include breakpoint($doc-sidenav-mobile-breakpoint) {
     display: flex;
     justify-content: flex-end;
 
@@ -204,7 +204,7 @@ $sidenav-title-left-padding: 22px;
 }
 
 .mobile-sidenav-holder {
-  @media(max-width: $doc-sidenav-mobile-breakpoint) {
+  @include breakpoint($doc-sidenav-mobile-breakpoint) {
     display: none;
     position: fixed !important;
     background-color: white;
@@ -220,7 +220,7 @@ $sidenav-title-left-padding: 22px;
 }
 
 .mobile-sidenav-opened {
-  @media(max-width: $doc-sidenav-mobile-breakpoint) {
+  @include breakpoint($doc-sidenav-mobile-breakpoint) {
     overflow: hidden;
   }
 
@@ -232,7 +232,7 @@ $sidenav-title-left-padding: 22px;
 #mobile-sidenav-toggle {
   display: none;
 
-  @media(max-width: $doc-sidenav-mobile-breakpoint) {
+  @include breakpoint($doc-sidenav-mobile-breakpoint) {
     display: block;
     padding: 0 15px;
     cursor: pointer;
@@ -240,7 +240,7 @@ $sidenav-title-left-padding: 22px;
     font-size: 15px;
     margin: 24px 0 8px;
 
-    @media (max-width: $phone-xlarge) {
+    @include breakpoint(lg-phone) {
       padding: 0;
     }
 

--- a/_hugo-theme/content/docs/1/introduction/diagrams/_index.md
+++ b/_hugo-theme/content/docs/1/introduction/diagrams/_index.md
@@ -1,4 +1,4 @@
 ---
-_build:
-  render: false
+build:
+  render: never
 ---

--- a/_hugo-theme/content/docs/1/resources/_index.md
+++ b/_hugo-theme/content/docs/1/resources/_index.md
@@ -4,7 +4,7 @@ headline: DDD Resources
 bodyclass: docs resources
 ---
 
-# Resources on Domain-Driven&nbsp;Design
+# Resources on Domain-Driven Design
 
 {{% note-block class="lead" %}}
 A brief selection of learning materials we recommend to the colleagues in DDD.

--- a/_hugo-theme/content/docs/1/resources/_index.md
+++ b/_hugo-theme/content/docs/1/resources/_index.md
@@ -1,7 +1,14 @@
 ---
 title: Resources
 headline: DDD Resources
+bodyclass: docs resources
 ---
+
+# Resources on Domain-Driven&nbsp;Design
+
+{{% note-block class="lead" %}}
+A brief selection of learning materials we recommend to the colleagues in DDD.
+{{% /note-block %}}
 
 {{< docs-card-container >}}
 

--- a/_hugo-theme/content/docs/1/resources/blogs.md
+++ b/_hugo-theme/content/docs/1/resources/blogs.md
@@ -1,6 +1,7 @@
 ---
 title: Blogs
 headline: DDD Resources
+bodyclass: docs resources
 ---
 
 # Blogs

--- a/_hugo-theme/content/docs/1/resources/communities.md
+++ b/_hugo-theme/content/docs/1/resources/communities.md
@@ -1,6 +1,7 @@
 ---
 title: Communities
 headline: DDD Resources
+bodyclass: docs resources
 ---
 
 # Communities

--- a/_hugo-theme/content/docs/1/resources/libraries.md
+++ b/_hugo-theme/content/docs/1/resources/libraries.md
@@ -1,6 +1,7 @@
 ---
 title: Libraries and Frameworks
 headline: DDD Resources
+bodyclass: docs resources
 ---
 
 # Libraries and Frameworks

--- a/_hugo-theme/content/docs/1/resources/sites.md
+++ b/_hugo-theme/content/docs/1/resources/sites.md
@@ -1,6 +1,7 @@
 ---
 title: Sites
 headline: DDD Resources
+bodyclass: docs resources
 ---
 
 # Sites

--- a/_hugo-theme/content/docs/_index.md
+++ b/_hugo-theme/content/docs/_index.md
@@ -1,4 +1,4 @@
 ---
-_build:
-  render: false
+build:
+  render: never
 ---

--- a/_hugo-theme/static/code-theme/dark.css
+++ b/_hugo-theme/static/code-theme/dark.css
@@ -43,16 +43,16 @@
 /* Line */ .chroma .line { display:flex; }
 /* Keyword */ .chroma .k { color:#ce8e6d }
 /* KeywordConstant */ .chroma .kc { color:#79c0ff }
-/* KeywordDeclaration */ .chroma .kd { color:#ff7b72 }
-/* KeywordNamespace */ .chroma .kn { color:#ff7b72 }
+/* KeywordDeclaration */ .chroma .kd { color:#f0883e }
+/* KeywordNamespace */ .chroma .kn { color:#f0883e }
 /* KeywordPseudo */ .chroma .kp { color:#79c0ff }
-/* KeywordReserved */ .chroma .kr { color:#ff7b72 }
-/* KeywordType */ .chroma .kt { color:#ff7b72 }
+/* KeywordReserved */ .chroma .kr { color:#f0883e }
+/* KeywordType */ .chroma .kt { color:#f0883e }
 /* Name */ .chroma .n {  }
-/* NameAttribute */ .chroma .na { color: #56a8f5 }
-/* NameClass */ .chroma .nc { color:#f0883e;font-weight:bold }
+/* NameAttribute */ .chroma .na { color: #a9b7c6 }
+/* NameClass */ .chroma .nc { color:#a9b7c7;font-weight:bold }
 /* NameConstant */ .chroma .no { color:#79c0ff;font-weight:bold }
-/* NameDecorator */ .chroma .nd { color:#d2a8ff;font-weight:bold }
+/* NameDecorator */ .chroma .nd { color:#f0883e;font-weight:bold }
 /* NameEntity */ .chroma .ni { color:#ffa657 }
 /* NameException */ .chroma .ne { color:#f0883e;font-weight:bold }
 /* NameLabel */ .chroma .nl { color:#79c0ff;font-weight:bold }
@@ -67,7 +67,7 @@
 /* NameVariableGlobal */ .chroma .vg { color:#79c0ff }
 /* NameVariableInstance */ .chroma .vi { color:#79c0ff }
 /* NameVariableMagic */ .chroma .vm { color:#79c0ff }
-/* NameFunction */ .chroma .nf { color:#d2a8ff;font-weight:bold }
+/* NameFunction */ .chroma .nf { color:#56a8f5;font-weight:bold }
 /* NameFunctionMagic */ .chroma .fm { color:#d2a8ff;font-weight:bold }
 /* Literal */ .chroma .l { color:#a5d6ff }
 /* LiteralDate */ .chroma .ld { color:#79c0ff }
@@ -77,7 +77,7 @@
 /* LiteralStringChar */ .chroma .sc { color:#a5d6ff }
 /* LiteralStringDelimiter */ .chroma .dl { color:#79c0ff }
 /* LiteralStringDoc */ .chroma .sd { color:#a5d6ff }
-/* LiteralStringDouble */ .chroma .s2 { color:#a5d6ff }
+/* LiteralStringDouble */ .chroma .s2 { color:#6aab73 }
 /* LiteralStringEscape */ .chroma .se { color:#79c0ff }
 /* LiteralStringHeredoc */ .chroma .sh { color:#79c0ff }
 /* LiteralStringInterpol */ .chroma .si { color:#a5d6ff }

--- a/_hugo-theme/static/code-theme/light.css
+++ b/_hugo-theme/static/code-theme/light.css
@@ -47,12 +47,12 @@
 /* KeywordNamespace */ .chroma .kn { color: #0000ff }
 /* KeywordPseudo */ .chroma .kp { color: #0000ff }
 /* KeywordReserved */ .chroma .kr { color: #0000ff }
-/* KeywordType */ .chroma .kt { color: #2b91af }
+/* KeywordType */ .chroma .kt { color: #0000ff }
 /* Name */ .chroma .n {  }
-/* NameAttribute */ .chroma .na {  }
+/* NameAttribute */ .chroma .na { color: #0000ff }
 /* NameBuiltin */ .chroma .nb {  }
 /* NameBuiltinPseudo */ .chroma .bp {  }
-/* NameClass */ .chroma .nc { color: #2b91af }
+/* NameClass */ .chroma .nc { color: #323232 }
 /* NameConstant */ .chroma .no {  }
 /* NameDecorator */ .chroma .nd {  }
 /* NameEntity */ .chroma .ni {  }
@@ -98,8 +98,8 @@
 /* Comment */ .chroma .c { color: #008000 }
 /* CommentHashbang */ .chroma .ch { color: #008000 }
 /* CommentMultiline */ .chroma .cm { color: #008000 }
-/* CommentSingle */ .chroma .c1 { color: #008000 }
-/* CommentSpecial */ .chroma .cs { color: #008000 }
+/* CommentSingle */ .chroma .c1 { color: #8c8c8c }
+/* CommentSpecial */ .chroma .cs { color: #8c8c8c }
 /* CommentPreproc */ .chroma .cp { color: #0000ff }
 /* CommentPreprocFile */ .chroma .cpf { color: #0000ff }
 /* Generic */ .chroma .g {  }


### PR DESCRIPTION
This PR cleans up styles and mixin using:
- Removes mixins that add the browser prefixes. These mixins are redundant because we do this automatically.
- Cleans up the media breakpoint using.
- Adds styles for the tooltip and enables tooltip for the code theme icon.
- Improves the code theme styles.