### PR TITLE
Use the link to Kurrent

### DIFF
--- a/docs/content/docs/1/introduction/prior-art.md
+++ b/docs/content/docs/1/introduction/prior-art.md
@@ -50,7 +50,7 @@ programming and immutable data.
 In Spine Event Engine we combined all of our experience and observations of the best-breed market
 products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), [Kurrent](https://www.kurrent.io/) 
 (formerly Event Store), [InfluxDB](https://influxdata.com/), [Apache Zest](https://zest.apache.org/) and many others. 
-Spine has yet to find its own niche.
+Spine has yet to find its own&nbsp;niche.
 
 Spine probably won’t be the best fit for trading or highly loaded applications, where, for example,
 [LMAX](https://www.lmax.com/) does an excellent job. Our motivation is to make development of

--- a/docs/content/docs/1/introduction/prior-art.md
+++ b/docs/content/docs/1/introduction/prior-art.md
@@ -48,9 +48,8 @@ getting so many things absolutely right: a simple, predictable state model; an e
 programming and immutable data.
 
 In Spine Event Engine we combined all of our experience and observations of the best-breed market
-products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), 
-[Event Store](https://geteventstore.com/), [InfluxDB](https://influxdata.com/), 
-[Apache Zest](https://zest.apache.org/) and many others. 
+products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), [Kurrent](https://www.kurrent.io/) 
+(formerly Event Store), [InfluxDB](https://influxdata.com/), [Apache Zest](https://zest.apache.org/) and many others. 
 Spine has yet to find its own niche.
 
 Spine probably won’t be the best fit for trading or highly loaded applications, where, for example,


### PR DESCRIPTION
This PR uses the link to [Kurrent](https://www.kurrent.io/) instead of the old `https://geteventstore.com/`:

<img width="694" height="134" alt="image" src="https://github.com/user-attachments/assets/3ae8d627-9ff3-4531-822e-7f3a6983bd31" />
