### PR TITLE
Add code tabs

### DIFF
--- a/docs/assets/js/docs-main.js
+++ b/docs/assets/js/docs-main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/js/docs-main.js
+++ b/docs/assets/js/docs-main.js
@@ -25,6 +25,7 @@
  */
 
 // Theme JS from the `TeamDev-Ltd/site-commons`.
+import 'js/components/code-tabs.js';
 /* TODO:2025-12-03:julia.evseeva: Enable when the icon position will be approved. */
 /*import 'js/components/copy-code.js'*/
 

--- a/docs/assets/scss/docs-common/code/_code-block.scss
+++ b/docs/assets/scss/docs-common/code/_code-block.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/scss/docs-common/code/_code-block.scss
+++ b/docs/assets/scss/docs-common/code/_code-block.scss
@@ -32,7 +32,8 @@
 */
 .code-block {
   $code-block-background: transparent;
-  $header-name-font-size: 12px;
+  $header-name-font-size: var(--code-tab-font-size);
+  $header-name-padding: 4px 0;
   $header-bg-color: var(--code-block-header-background);
   $header-divider-color: var(--code-block-header-divider-color);
 
@@ -49,11 +50,11 @@
     border-bottom: 1px solid $header-divider-color;
 
     .file-name {
-      color: var(--code-block-text-color);
+      color: #3a3a3a;
       font-size: $header-name-font-size;
-      font-weight: bold;
+      font-weight: 400;
       line-height: 1;
-      padding: 14px $code-block-padding;
+      padding: $header-name-padding;
     }
 
     .copy-code-to-clipboard-icon {

--- a/docs/assets/scss/docs-common/code/_code-block.scss
+++ b/docs/assets/scss/docs-common/code/_code-block.scss
@@ -31,9 +31,9 @@
   shortcode with the file name parameter or with using the `code-tabs`.
 */
 .code-block {
-  $code-block-background: var(--code-block-background);
+  $code-block-background: transparent;
   $header-name-font-size: 12px;
-  $header-bg-color: var(--code-block-background);
+  $header-bg-color: var(--code-block-header-background);
   $header-divider-color: var(--code-block-header-divider-color);
 
   margin-bottom: 40px;

--- a/docs/assets/scss/docs-common/code/_code-tabs.scss
+++ b/docs/assets/scss/docs-common/code/_code-tabs.scss
@@ -44,7 +44,7 @@
   .tabs {
     position: relative;
     display: flex;
-    column-gap: 16px;
+    column-gap: 24px;
     margin-bottom: 12px;
 
     .indicator {

--- a/docs/assets/scss/docs-common/code/_code-tabs.scss
+++ b/docs/assets/scss/docs-common/code/_code-tabs.scss
@@ -34,7 +34,7 @@
   $code-tab-indicator-color: var(--code-tab-indicator-color);
   $code-tab-font: var(--main-font);
   $code-tab-padding: 4px 0;
-  $code-tab-font-size: 15px;
+  $code-tab-font-size: var(--code-tab-font-size);
   $border-radius: 3px;
   $indicator-line-height: 2px;
   $indicator-line-border-radius: calc($indicator-line-height / 2);

--- a/docs/assets/scss/docs-common/code/_code-tabs.scss
+++ b/docs/assets/scss/docs-common/code/_code-tabs.scss
@@ -65,7 +65,7 @@
       font-family: $code-tab-font;
       color: $code-tab-color;
       font-weight: bold;
-      font-size: 12px;
+      font-size: 13px;
       line-height: 1;
       transition: color .2s ease-in-out;
       cursor: pointer;
@@ -82,7 +82,7 @@
             bottom: -1px;
             width: 100%;
             height: $indicator-line-height;
-            background: red;
+            background: $code-tab-indicator-color;
           }
         }
       }
@@ -96,9 +96,17 @@
   }
 
   .code-tab-content {
+    &:not(:has(.highlight)) {
+      padding-top: 16px;
+    }
+
     p {
       padding-top: 0 !important;
       margin-bottom: 8px;
+    }
+
+    ul:last-child {
+      margin-bottom: 0;
     }
   }
 }

--- a/docs/assets/scss/docs-common/code/_code-tabs.scss
+++ b/docs/assets/scss/docs-common/code/_code-tabs.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/scss/docs-common/code/_code-tabs.scss
+++ b/docs/assets/scss/docs-common/code/_code-tabs.scss
@@ -33,16 +33,19 @@
   $code-tab-active-color: var(--code-tab-active-color);
   $code-tab-indicator-color: var(--code-tab-indicator-color);
   $code-tab-font: var(--main-font);
-  $code-tab-padding: 14px 16px;
+  $code-tab-padding: 4px 0;
+  $code-tab-font-size: 15px;
   $border-radius: 3px;
-  $indicator-line-height: 3px;
-  $indicator-line-border-radius: $indicator-line-height/2;
+  $indicator-line-height: 2px;
+  $indicator-line-border-radius: calc($indicator-line-height / 2);
 
   margin: 20px 0 32px;
 
   .tabs {
     position: relative;
     display: flex;
+    column-gap: 16px;
+    margin-bottom: 12px;
 
     .indicator {
       content: '';
@@ -64,8 +67,8 @@
       padding: $code-tab-padding;
       font-family: $code-tab-font;
       color: $code-tab-color;
-      font-weight: bold;
-      font-size: 13px;
+      font-weight: 500;
+      font-size: $code-tab-font-size;
       line-height: 1;
       transition: color .2s ease-in-out;
       cursor: pointer;
@@ -94,21 +97,6 @@
       }
     }
   }
-
-  .code-tab-content {
-    &:not(:has(.highlight)) {
-      padding-top: 16px;
-    }
-
-    p {
-      padding-top: 0 !important;
-      margin-bottom: 8px;
-    }
-
-    ul:last-child {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .code-tab-content {
@@ -122,7 +110,19 @@
     display: inline-block;
   }
 
-  p:first-child {
-    padding-top: 0 !important;
+  p {
+    &:first-child {
+      padding-top: 0 !important;
+    }
+
+    &:has(> embed-code) {
+      display: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+
+  ul:last-child {
+    margin-bottom: 0;
   }
 }

--- a/docs/assets/scss/docs-common/code/_code.scss
+++ b/docs/assets/scss/docs-common/code/_code.scss
@@ -28,34 +28,30 @@
   --code-background: #ffffff;
   --code-text-color: inherit;
   --code-padding: 0;
+
+  --code-block-header-divider-color: transparent;
+  --code-block-header-background: transparent;
+  --code-tab-color: #818181;
+  --code-tab-active-color: #1a96de;
+  --code-tab-indicator-color: #1a96de;
 }
 
 .dark-code-theme {
   --code-block-background: #2b2b2b;
   --code-block-text-color: #a9b7c6;
   --code-block-box-shadow: unset;
-  --code-block-header-divider-color: transparent;
-  --code-block-header-background: transparent;
   --code-block-highlighted-line-bg: #383636;
   --copy-code-icon-color: #{$gray-600};
   --copy-code-icon-hover-color: rgba(255, 255, 255, .8);
-  --code-tab-color: #{$gray-600};
-  --code-tab-active-color: var(--text-color);
-  --code-tab-indicator-color: #1a96de;
 }
 
 .light-code-theme {
   --code-block-background: #ffffff;
   --code-block-text-color: var(--text-color);
   --code-block-box-shadow: 0 3px 12px 0 rgba(35, 37, 38, .1);
-  --code-block-header-divider-color: transparent;
-  --code-block-header-background: transparent;
   --code-block-highlighted-line-bg: #e9f0e9;
   --copy-code-icon-color: #{$gray-600};
   --copy-code-icon-hover-color: #{$gray-700};
-  --code-tab-color: #{$gray-600};
-  --code-tab-active-color: var(--text-color);
-  --code-tab-indicator-color: #1a96de;
 }
 
 $mono-font-family: $main-mono-font;

--- a/docs/assets/scss/docs-common/code/_code.scss
+++ b/docs/assets/scss/docs-common/code/_code.scss
@@ -34,6 +34,7 @@
   --code-tab-color: #818181;
   --code-tab-active-color: #1a96de;
   --code-tab-indicator-color: #1a96de;
+  --code-tab-font-size: 15px;
 }
 
 .dark-code-theme {

--- a/docs/assets/scss/docs-common/code/_code.scss
+++ b/docs/assets/scss/docs-common/code/_code.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/scss/docs-common/code/_code.scss
+++ b/docs/assets/scss/docs-common/code/_code.scss
@@ -34,26 +34,28 @@
   --code-block-background: #2b2b2b;
   --code-block-text-color: #a9b7c6;
   --code-block-box-shadow: unset;
-  --code-block-header-divider-color: rgba(255, 255, 255, .08);
+  --code-block-header-divider-color: transparent;
+  --code-block-header-background: transparent;
   --code-block-highlighted-line-bg: #383636;
   --copy-code-icon-color: #{$gray-600};
   --copy-code-icon-hover-color: rgba(255, 255, 255, .8);
   --code-tab-color: #{$gray-600};
-  --code-tab-active-color: #f8f8f2;
-  --code-tab-indicator-color: #{$gray-700};
+  --code-tab-active-color: var(--text-color);
+  --code-tab-indicator-color: #1a96de;
 }
 
 .light-code-theme {
   --code-block-background: #ffffff;
   --code-block-text-color: var(--text-color);
   --code-block-box-shadow: 0 3px 12px 0 rgba(35, 37, 38, .1);
-  --code-block-header-divider-color: rgba(0, 0, 0, .07);
+  --code-block-header-divider-color: transparent;
+  --code-block-header-background: transparent;
   --code-block-highlighted-line-bg: #e9f0e9;
   --copy-code-icon-color: #{$gray-600};
   --copy-code-icon-hover-color: #{$gray-700};
   --code-tab-color: #{$gray-600};
   --code-tab-active-color: var(--text-color);
-  --code-tab-indicator-color: $main-brand-color;
+  --code-tab-indicator-color: #1a96de;
 }
 
 $mono-font-family: $main-mono-font;

--- a/docs/assets/scss/docs/modules/_article-container.scss
+++ b/docs/assets/scss/docs/modules/_article-container.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/scss/docs/modules/_article-container.scss
+++ b/docs/assets/scss/docs/modules/_article-container.scss
@@ -58,7 +58,15 @@ $article-container-min-height: 460px;
     --code-block-padding: 20px;
   }
 
+  .code-tabs {
+    margin: 8px 0 40px;
+  }
+
   .highlight {
+    &:not(.code-tabs .highlight) {
+      margin: 8px 0 40px;
+    }
+
     // Applies negative margins only to the parent `chroma` element.
     // Useful for the default and table views with the numbered lines.
     > .chroma {

--- a/docs/assets/scss/docs/modules/_article-text.scss
+++ b/docs/assets/scss/docs/modules/_article-text.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/assets/scss/docs/modules/_article-text.scss
+++ b/docs/assets/scss/docs/modules/_article-text.scss
@@ -217,10 +217,6 @@
     color: $black;
   }
 
-  .highlight {
-    margin: 8px 0 40px;
-  }
-
   .date {
     font-family: $main-font;
     font-size: 14px;


### PR DESCRIPTION
This PR enables the code tabs JS for future use. It also adjusts the tab styling due to the full-width code blocks layout.

The style is the same as it was in Jekyll implementation:

<img width="819" height="161" alt="image" src="https://github.com/user-attachments/assets/10360f62-870b-4b76-9ebb-91f33a5897ce" />
