### PR TITLE
Run `npm install` before building the site

### DIFF
--- a/_script/install-dependencies
+++ b/_script/install-dependencies
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
+
+cd site
+npm install

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
  * Builds and runs the site locally.
  */
 task<Exec>("runSite") {
+    dependsOn("installDependencies")
     commandLine("./_script/hugo-serve")
 }
 
@@ -35,7 +36,15 @@ task<Exec>("runSite") {
  * Builds the site without starting the server.
  */
 task<Exec>("buildSite") {
+    dependsOn("installDependencies")
     commandLine("./_script/hugo-build")
+}
+
+/**
+ * Installs the Node.js dependencies required for building the site.
+ */
+task<Exec>("installDependencies") {
+    commandLine("./_script/install-dependencies")
 }
 
 /**
@@ -56,10 +65,11 @@ task<Exec>("checkSamples") {
  * Builds all included projects via depending on the top-level "buildAll" tasks
  * declared in these projects.
  *
- * @see https://discuss.gradle.org/t/defining-a-composite-build-only-to-build-all-subprojects/25070/6
- * @see https://github.com/AlexMAS/gradle-composite-build-example
- * @see https://docs.gradle.org/current/userguide/composite_builds.html
+ * See also:
+ *  * [Composite build to build subprojects](https://discuss.gradle.org/t/defining-a-composite-build-only-to-build-all-subprojects/25070/6)
+ *  * [Gradlew composite build example](https://github.com/AlexMAS/gradle-composite-build-example)
+ *  * [Composite builds](https://docs.gradle.org/current/userguide/composite_builds.html)
  */
-tasks.register("buildAll")  {
+tasks.register("buildAll") {
     dependsOn(gradle.includedBuilds.map { it.task(":buildAll") })
 }

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -6,7 +6,7 @@ title: Documentation preview
 
 Go to the [documentation section](docs/).
 
-Read a [guide][authoring] on adding the content to the documentation.
+Read the [Authoring][authoring] guide on adding the content to the documentation.
 
 <p class="subtle">The page is only available on this site and will not be 
 rendered on the <a href="https://spine.io">spine.io</a>.</p>


### PR DESCRIPTION
This PR improves the onboarding scenario for people new to the documentation by running `npm install` before building the site. Previously, the command had to be run manually. Otherwise, the build failed because of the missing dependencies.

### Other notable changes
 * Fixed documentation links in the Gradle script file to avoid IDE syntax warnings.
 * Fixed the reference to the Authoring guide in the site index page.

