### PR TITLE
Fix root project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "spine.io"
+rootProject.name = "spine-docs"
 
 includeBuild("./_code/samples")
 


### PR DESCRIPTION
This PR fixes the root project name value set in the `settings.gradle.kts` file. Previously, the name was `spine.io` which was misleading because this project is about the `docs` section of the site.