### PR TITLE
Use semantic coloring for code names in texts

### DIFF
--- a/docs/_preview/go.mod
+++ b/docs/_preview/go.mod
@@ -3,7 +3,7 @@ module github.com/SpineEventEngine/documentation/docs/_preview
 go 1.22.0
 
 require (
-	github.com/SpineEventEngine/site-commons v0.0.0-20260213171221-c1157022c545 // indirect
+	github.com/SpineEventEngine/site-commons v0.0.0-20260217160941-2a1a87ca8cfb // indirect
 	github.com/SpineEventEngine/validation/docs v0.0.0-20260205202311-181ba8844107 // indirect
 	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
 	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect

--- a/docs/_preview/go.sum
+++ b/docs/_preview/go.sum
@@ -1,5 +1,5 @@
-github.com/SpineEventEngine/site-commons v0.0.0-20260213171221-c1157022c545 h1:NI8WYIfw5yv/FXNhxG2zgiU3J0YChheRQugosxkopoc=
-github.com/SpineEventEngine/site-commons v0.0.0-20260213171221-c1157022c545/go.mod h1:tkAl4StIREKmz9r5PiJtuDhvwMMkFXKWcaTyxhIikho=
+github.com/SpineEventEngine/site-commons v0.0.0-20260217160941-2a1a87ca8cfb h1:4OsCLSX35TznTy8qs/l8HkFUYKNPfMF/tgO1iYe9LfI=
+github.com/SpineEventEngine/site-commons v0.0.0-20260217160941-2a1a87ca8cfb/go.mod h1:tkAl4StIREKmz9r5PiJtuDhvwMMkFXKWcaTyxhIikho=
 github.com/SpineEventEngine/validation/docs v0.0.0-20260205202311-181ba8844107 h1:2DHRIwwLudP6l3Kh7Nd4KR4uXcsDtIAXE9adW68ivME=
 github.com/SpineEventEngine/validation/docs v0.0.0-20260205202311-181ba8844107/go.mod h1:STHyjXejVvPmfrxujfDvhofmjg55mMk+fwI3TVL0b4Y=
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWwrtijAhUbf3BiRLmpO5j34bgl1ggU=

--- a/docs/content/docs/examples/_index.md
+++ b/docs/content/docs/examples/_index.md
@@ -19,7 +19,7 @@ Please see the selected list of the examples with the descriptions below.
 - [Kanban]({{% get-site-data "repositories.examples" %}}/kanban/) — shows orchestrating 
   Aggregates using Process Managers.
 - [Airport]({{% get-site-data "repositories.examples" %}}/airport/) — integrating 
-  a third-party systems using a Bounded Context. This example accompanies 
+  a third-party system using a Bounded Context. This example accompanies 
   the [“Integration with a Third Party”](docs/guides/integration/) guide.
 - [To-Do List]({{% get-site-data "repositories.examples" %}}/todo-list/) — a simple 
   task management system with multiple client applications. 

--- a/docs/content/docs/examples/_index.md
+++ b/docs/content/docs/examples/_index.md
@@ -31,4 +31,4 @@ Please see the selected list of the examples with the descriptions below.
 - [Simple HTML/JS To-Do List client]({{% get-site-data "repositories.examples" %}}/todo-list/tree/master/client/html-js/)
   — a client app with very basic features.
 - [To-Do List client on Angular]({{% get-site-data "repositories.examples" %}}/todo-list/tree/master/client/angular/)
-  — a more featured client built with Angular 10.
+  — a more featured client built with Angular&nbsp;10.

--- a/docs/content/docs/guides/integration.md
+++ b/docs/content/docs/guides/integration.md
@@ -328,7 +328,7 @@ private void emitIfStatusKnown(TsaPassenger tsaPassenger) {
 }
 ```
 The [Process Manager]({{% get-site-data "repositories.examples" %}}/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java)
-accumulates the Events and, once the whole *Flight* is boarded, emits a `BoardingComplete` event,
+accumulates the Events and, once the whole *Flight* is boarded, emits a {{< code "event" "BoardingComplete" >}} event,
 which is later consumed by the&nbsp;[*Flight* Aggregate]({{% get-site-data "repositories.examples" %}}/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/FlightAggregate.java).
 
 <embed-code file="examples/airport/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java" 

--- a/docs/content/docs/guides/start-new-project.md
+++ b/docs/content/docs/guides/start-new-project.md
@@ -148,7 +148,7 @@ and polish the code of this important development step.
 ### Events
 
 When the IDs are defined it’s time to define [event][event-concept] messages. The events are named 
-as facts formulated as past participles, e.g. `RepositoryRegistered` or `TaskCreated`. 
+as facts formulated as past participles, e.g. {{< code "event" "RepositoryRegistered" >}} or {{< code "event" "TaskCreated" >}}. 
 They are defined in files with the [`_events.proto`][events-proto] suffix (e.g. `order_events.proto`, 
 `customer_events.proto`). If your context is small it can be just `events.proto`.
 
@@ -158,8 +158,8 @@ Create a Pull Request with the event definitions when they are ready.
 
 Similar to events, [command][command-concept] messages are defined in files having the names ending 
 with the [`_commands.proto`][commands-proto] suffix (or just `commands.proto` for a small context). 
-Commands are defined as imperative in a form of “do something”, e.g. `RegisterRepository` 
-or `CreateTask`.
+Commands are defined as imperative in a form of “do something”, e.g. {{< code "command" "RegisterRepository" >}} 
+or {{< code "command" "CreateTask" >}}.
 
 Finalize defining commands with a Pull Request.
 
@@ -189,8 +189,8 @@ The [entity state][entity-state-naming] is a holder of the entity data. It does 
 a whole [entity][entity-concept] but depicts the shape of its data.
 
 The definitions of entity states are [gathered][entity-state-proto] in a file named after 
-a business model thing. E.g. for a `Task` aggregate, the definitions would be defined in 
-a `task.proto` file.
+a business model thing. E.g. for a {{< code "aggregate" "Task" >}} aggregate, the definitions 
+would be defined in a `task.proto` file.
 
 As with the other steps, create a Pull Request to review the entity states with the&nbsp;team.
 
@@ -208,7 +208,7 @@ the business logic the same way it works in the application.
 All the code must conform to your standards of the code and documentation quality 
 and be tested thoroughly.
 
-When a backend for the scenario is done a new PR is created and reviewed.
+When a backend for the scenario is done a new PR is created and&nbsp;reviewed.
 
 ### Fulfilling the vertical
 
@@ -221,7 +221,7 @@ with the previous one.
 As noted, the scope of this iteration is to prepare the front-facing part for the scenario: 
 either a UI if one is needed, or the public API, or a dedicated idiomatic client.
 
-As soon as the implementation is ready, another PR and review come along.
+As soon as the implementation is ready, another PR and review come&nbsp;along.
 
 ## Start over again
 

--- a/docs/content/docs/guides/start-new-project.md
+++ b/docs/content/docs/guides/start-new-project.md
@@ -158,8 +158,8 @@ Create a Pull Request with the event definitions when they are ready.
 
 Similar to events, [command][command-concept] messages are defined in files having the names ending 
 with the [`_commands.proto`][commands-proto] suffix (or just `commands.proto` for a small context). 
-Commands are defined as imperative in a form of “do something”, e.g. {{< code "command" "RegisterRepository" >}} 
-or {{< code "command" "CreateTask" >}}.
+Commands are defined as imperative in a form of “do something”, e.g. 
+{{< code "command" "RegisterRepository" >}} or {{< code "command" "CreateTask" >}}.
 
 Finalize defining commands with a Pull Request.
 

--- a/docs/content/docs/guides/validation.md
+++ b/docs/content/docs/guides/validation.md
@@ -23,7 +23,7 @@ that define correctness of data are also defined at this level using custom Prot
 
 {{% note-block class="note" %}}
 In order to use validation features, you don't need to understand how custom
-options work. Those who are interested in the details of this <em>advanced feature</em> of Protobuf,
+options work. Those who are interested in the details of this _advanced feature_ of Protobuf,
 please see the [Protobuf Guide](https://developers.google.com/protocol-buffers/docs/proto3#custom_options)
 for details.
 {{% /note-block %}}

--- a/docs/content/docs/guides/validation.md
+++ b/docs/content/docs/guides/validation.md
@@ -318,8 +318,8 @@ therefore it is implicitly required. By default, the framework will use it in co
 as an identifier of the entity handling this command.
 
 This convention does not apply to [Events](docs/introduction/naming-conventions#eventsproto).
-Unlike Commands, event routing is typically specific to the use case. For example, `UserView` projection
-may require a user ID to handle events, whereas the `ProfilePictureGallery` projection might use
+Unlike Commands, event routing is typically specific to the use case. For example, {{< code "projection" "UserView" >}} projection
+may require a user ID to handle events, whereas the {{< code "projection" "ProfilePictureGallery" >}} projection might use
 a different routing approach, such as grouping by a user group or an email domain associated with a user.
 
 Therefore, all Event fields are not required by default.

--- a/docs/content/docs/introduction/_index.md
+++ b/docs/content/docs/introduction/_index.md
@@ -150,11 +150,11 @@ final class TaskItemProjection
 #### Repositories
 The framework provides default implementations for repositories.
 A custom `Repository` class may be needed for:
-  * <strong>Dispatching messages to entities in a non-standard way</strong>.
+  * **Dispatching messages to entities in a non-standard way**.
     By default, a command is dispatched using the first field of the command message
     as an ID of the target entity.
     An event is dispatched by the ID of the entity which emitted the event.
-  * <strong>Domain-specific operations</strong> on entities of this kind.
+  * **Domain-specific operations** on entities of this kind.
   
 Repositories are added to the Bounded Context they belong when it is created:
 
@@ -170,8 +170,8 @@ This wires repositories into the message delivery mechanism of the corresponding
   
 #### Testing
 Implementation of the Bounded Context is tested using the messaging paradigm.
-The following code snippet asserts that handling a command `CreateTask` produces one 
-`TaskCreated` event with expected arguments.
+The following code snippet asserts that handling a command {{< code "command" "CreateTask" >}} 
+produces one {{< code "event" "TaskCreated" >}} event with expected arguments.
 
 ```java
 // Given

--- a/docs/content/docs/introduction/concepts.md
+++ b/docs/content/docs/introduction/concepts.md
@@ -40,9 +40,9 @@ regular events. If an event is a fact of something that happened to a domain mod
 a fact that states the reason why a command was not handled.  
 
 Consider the following examples of rejections: 
-* `CreditCardValidationDeclined`, 
-* `OrderCannotBeEmpty`, 
-* `InsufficientFunds`.
+* {{< code "rejection" "CreditCardValidationDeclined" >}},
+* {{< code "rejection" "OrderCannotBeEmpty" >}},
+* {{< code "rejection" "InsufficientFunds" >}}.
 
 In Spine, rejections are defined as Protobuf messages in the file which names ends with
 `rejections.proto`. 
@@ -85,8 +85,8 @@ final class TaskAggregate
 
 Event Subscriber is an object which subscribes to receive events.
 
-The example below shows how a [Projection](#projection) class subscribed to the `TaskCompleted`
-event.
+The example below shows how a [Projection](#projection) class subscribed 
+to the {{< code "event" "TaskCompleted" >}} event.
 
 ```java
 final class TaskProjection

--- a/docs/content/docs/introduction/naming-conventions.md
+++ b/docs/content/docs/introduction/naming-conventions.md
@@ -91,10 +91,10 @@ an event, and it is likely there are conditions under which a command cannot be 
 ### Entity states
 
 We recommend gathering definition of related entity states in a file named after a business model
-thing. Suppose we have a `Task` aggregate, `TaskItem` and `TaskDetails` projections, and
-a Process Manager which is responsible for movement of a task from one project to another, there
-would be `task.proto` file, with all Task-related data types definitions. A project-related data
-types would be defined in a `project.proto` file. 
+thing. Suppose we have a {{< code "aggregate" "Task" >}} aggregate, {{< code "projection" "TaskItem" >}} 
+and {{< code "projection" "TaskDetails" >}} projections, and a Process Manager which is responsible for 
+movement of a task from one project to another, there would be `task.proto` file, with all Task-related 
+data types definitions. The project-related data types would be defined in a `project.proto` file. 
 
 As it was already mentioned, `TaskId` and `ProjectId` are defined in the `identifiers.proto` file,
 and `task.proto` and `project.proto` import this file.

--- a/docs/content/docs/introduction/naming-conventions.md
+++ b/docs/content/docs/introduction/naming-conventions.md
@@ -222,26 +222,26 @@ message CreateTask {
 
 A command is defined as an imperative:
 
- * `CreateProject`
- * `AssignTask`
- * `RemoveComment`
+ * {{< code "command" "CreateProject" >}}
+ * {{< code "command" "AssignTask" >}}
+ * {{< code "command" "RemoveComment" >}}
  
 ### Events
 
 Events are named as facts formulated as past participles, for example:
 
-  * `ProjectCreated`
-  * `TaskAssigned`
-  * `CommentRemoved`   
+  * {{< code "event" "ProjectCreated" >}}
+  * {{< code "event" "TaskAssigned" >}}
+  * {{< code "event" "CommentRemoved" >}}
 
 ### Rejections
 
 A rejection is named after a reason of why a command cannot be handled. In fact, rejection notifies
 on a state of the domain model, for example:
 
-  * `TaskAlreadyExists`
-  * `InsufficientFunds` 
-  * `ProjectAlreadyCompleted`
+  * {{< code "rejection" "TaskAlreadyExists" >}}
+  * {{< code "rejection" "InsufficientFunds" >}}
+  * {{< code "rejection" "ProjectAlreadyCompleted" >}}
 
 ### Entity states
 

--- a/docs/content/docs/quick-start/_index.md
+++ b/docs/content/docs/quick-start/_index.md
@@ -1003,8 +1003,7 @@ using Protobuf. Using these `.proto` files Spine Model Compiler generates the co
 the defined data types.
 
 After that, we add the business logic for handling commands or events in entity classes derived from
-{{< code "aggregate" "Aggregate" >}}, {{< code "process-manager" "ProcessManager" >}}, 
-or {{< code "projection" "Projection" >}}.
+`Aggregate`, `ProcessManager`, or `Projection`.
 
 Then,  these entity types are assembled into a Bounded Context and tested as a whole.
 A test suite sends signals (i.e. commands or events) to the implementation of the Bounded Context

--- a/docs/content/docs/quick-start/_index.md
+++ b/docs/content/docs/quick-start/_index.md
@@ -193,7 +193,7 @@ Now, let's look into the data structure of the Hello context.
 The data types of the Hello context are defined under the `src/main/proto/hello` directory with
 the following files:
 
-  * **`commands.proto`** — this file defines the `Print` command.
+  * **`commands.proto`** — this file defines the {{< code "command" "Print" >}} command.
   
 {{% note-block class="note" %}}
 By convention, commands are defined in a file with the `commands` suffix
@@ -201,15 +201,16 @@ in its name. It can be, for example, `order_commands.proto` or just `commands.pr
 like in our example.
 {{% /note-block %}}
      
-  * **`events.proto`** — this file defines the `Printed` event.
+  * **`events.proto`** — this file defines the {{< code "event" "Printed" >}} event.
   
 {{% note-block class="note" %}}
 Similarly to commands, events are defined in proto files having the `events`
 suffix in their names.
 {{% /note-block %}}
 
-These two files define signals used by the Hello context. There's also data of the `Console`
-Process Manager, which is defined in the package **`server`** in the file **`console.proto`**.
+These two files define signals used by the Hello context. There's also data of the 
+{{< code "process-manager" "Console" >}} Process Manager, which is defined in the 
+package **`server`** in the file **`console.proto`**.
 
 {{% note-block class="note" %}}
 We arrange the sub-package `server` to highlight the fact that this is server-only data. It is not
@@ -237,7 +238,7 @@ required for all proto files of a Spine-based project.
 import "spine/options.proto";
 ```
 
-The following file-wide option defines the prefix for type names used in this file.
+The following file-wide option defines the prefix for type names used in this&nbsp;file.
 
 <embed-code file="examples/hello/src/main/proto/hello/commands.proto" 
             start="type_url_prefix"
@@ -284,7 +285,7 @@ Outer classes are used by Protobuf implementation internally.
 When the `java_outer_classname` option is omitted, Protobuf Compiler would calculate the Java
 class name taking the name of the corresponding `.proto` file. 
 We recommend setting the name directly to make it straight. This also avoids possible name clashes
-with the handcrafted code.
+with the handcrafted&nbsp;code.
 {{% /note-block %}} 
 
 The next standard option instructs the Protobuf Compiler to put each generated Java type into
@@ -396,7 +397,7 @@ The header of the file is similar to those we saw in `commands.proto` and `event
 The difference is that we use `server` for the proto and Java package names to make sure the 
 server-only is not used by the client code.
  
-This file defines a single data type. It is the state of the entity handling the `Print` command:
+This file defines a single data type. It is the state of the entity handling the {{< code "command" "Print" >}} command:
 
 <embed-code file="examples/hello/src/main/proto/hello/server/console.proto" 
             start="message Output" 
@@ -464,7 +465,7 @@ Printed handle(Print command) {
 Let's review the method in details.
 
 The `@Assign` annotation tells that we assign this method to handle the command which the
-method accepts as the parameter. The method returns the event message `Printed`.
+method accepts as the parameter. The method returns the event message {{< code "event" "Printed" >}}.
 
 The following code obtains the name of the user, and the text to print from the received command,
 and then applies them to the state of the Process Manager. Instances of the `Console` class store
@@ -615,9 +616,10 @@ protected BoundedContextBuilder contextBuilder() {
     return HelloContext.newBuilder();
 }
 ```
-Now we can get down to the tests. The suite verifiers the outcome of the `Print` command.
-The test methods are gathered under the nested class called
-`PrintCommand`. The class holds the reference to the command as its field:
+Now we can get down to the tests. The suite verifiers the outcome of the 
+{{< code "command" "Print" >}} command. The test methods are gathered under 
+the nested class called `PrintCommand`. The class holds the reference to the 
+command as its field:
 
 <embed-code file="examples/hello/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java" 
             start="@Nested" 
@@ -822,7 +824,7 @@ Again, similarly to a `Server`, a `Client` is created using in-process connectio
 The `shutdownTimeout` parameter configures the amount of time allowed for completing ongoing
 client-server communications. 
 
-Now, let's review the main thing the `Client` class does, sending the `Print` command.
+Now, let's review the main thing the `Client` class does, sending the {{< code "command" "Print" >}} command.
 
 ### Sending the command
 
@@ -847,9 +849,9 @@ public void sendCommand() {
 
 The method does three things:
    1. Creates a command message using the login name of the current computer user.
-   2. Subscribes to the `Printed` event which will be generated as the result of
-      handling the command we are going to post (and only this instance of the command,
-      not all `Print` commands).  
+   2. Subscribes to the {{< code "event" "Printed" >}} event which will be generated 
+      as the result of handling the command we are going to post (and only this instance 
+      of the command, not all {{< code "command" "Print" >}} commands).  
    3. Posts the command. 
       
 Let's review subscribing and posting in details.
@@ -860,18 +862,18 @@ most of the commands using `client.onBehalfOf(UserId)`.
 
 The `command(commandMessage)` call tells we want to send a command with the passed message.
 
-Then, we subscribe to the `Printed` event which would be generated as the result of handling
-the command. The events obtained from the server would be passed to the `onPrinted()` method
-of the `Client` class.
+Then, we subscribe to the {{< code "event" "Printed" >}} event which would be
+generated as the result of handling the command. The events obtained from the
+server would be passed to the `onPrinted()` method of the `Client` class.
 
 The `post()` method sends the command to the server, returning the set with one `Subscription`
-to the `Printed` event. We store the returned set in the field to use later for cancelling
-the subscription.  
+to the {{< code "event" "Printed" >}} event. We store the returned set in the field 
+to use later for cancelling the subscription.  
 
 ### Handling the event
 
-When the client code receives the `Printed` event, it prints its data and then 
-cancels the subscription:
+When the client code receives the {{< code "event" "Printed" >}} event, it prints 
+its data and then cancels the subscription:
 
 <embed-code file="examples/hello/src/main/java/io/spine/helloworld/client/Client.java" 
             start="void onPrinted(" 
@@ -1001,7 +1003,8 @@ using Protobuf. Using these `.proto` files Spine Model Compiler generates the co
 the defined data types.
 
 After that, we add the business logic for handling commands or events in entity classes derived from
-`Aggregate`, `ProcessManager`, or `Projection`. 
+{{< code "aggregate" "Aggregate" >}}, {{< code "process-manager" "ProcessManager" >}}, 
+or {{< code "projection" "Projection" >}}.
 
 Then,  these entity types are assembled into a Bounded Context and tested as a whole.
 A test suite sends signals (i.e. commands or events) to the implementation of the Bounded Context

--- a/docs/content/docs/quick-start/_index.md
+++ b/docs/content/docs/quick-start/_index.md
@@ -15,7 +15,7 @@ it won't take long.
 ## What we'll do
 
 We'll go through the example which shows a Bounded Context called “Hello”. 
-The context has one `ProcessManager`, which handles the `Print` command
+The context has one `ProcessManager`, which handles the {{< code "command" "Print" >}} command
 sent from the client-side code to the server-side code hosting the context. 
 We'll go through the production code of the example suite, and through the code which
 tests the Hello&nbsp;context.
@@ -65,12 +65,11 @@ The first line tells which Gradle task we run. The following couple of lines is 
 logging that informs us that the server was started. 
 
 The line with the `Environment` tells that we're running the application in the `Production` 
-environment.
-The line with “Hello World!” text is the “meat” of this example suite. 
-It is what our `ProcessManager` (called `Console`) does in response to the `Print` command received
-from the `Client`. 
-The text in between brackets is the name of the current computer user. The name was passed as
-the argument of the `Print` command.
+environment. The line with “Hello World!” text is the “meat” of this example suite. 
+It is what our `ProcessManager` (called `Console`) does in response to the 
+{{< code "command" "Print" >}} command received from the `Client`. The text 
+in between brackets is the name of the current computer user. The name was passed 
+as the argument of the {{< code "command" "Print" >}} command.
 
 {{% note-block class="note" %}}
 We opted to show a `ProcessManager` — instead of an `Aggregate` — because
@@ -79,8 +78,8 @@ that is the job of Process Managers. We also want to highlight the importance of
 this architectural pattern.
 {{% /note-block %}}
 
-The output that follows is the logging produced by the `Client` class as it receives the `Printed`
-event from the server.
+The output that follows is the logging produced by the `Client` class as it receives the
+{{< code "event" "Printed" >}} event from the server.
 
 Then, the server shuts down concluding the example.   
 
@@ -433,7 +432,7 @@ final class Console extends ProcessManager<String, Output, Output.Builder> {
 
 The generic arguments passed to `ProcessManager` are:
  1. `String` — the type of the ID of the entity. Remember the type
-of the first field of the `Print` command?
+    of the first field of the {{< code "command" "Print" >}} command?
 
  2. `Output` — the type of the entity state, which we reviewed in the previous section.
 
@@ -523,8 +522,8 @@ After the event is generated, it is posted to the `EventBus` and delivered to
 subscribers automatically. You don't need to write any code for this.
 {{% /note-block %}}  
 
-Now, let's see how the `Console` Process Manager is exposed to the outer world so that it can
-receive commands.
+Now, let's see how the {{< code "process-manager" "Console" >}} Process Manager 
+is exposed to the outer world so that it can receive commands.
 
 ## Assembling the Hello context
 
@@ -679,8 +678,9 @@ void event() {
 
 ### Testing entity state update
 
-For testing the state of the `Console` Process Manager was updated, we construct the expected
-state and pass it to the `assertState()` method of the test fixture:
+For testing the state of the {{< code "process-manager" "Console" >}} Process Manager 
+was updated, we construct the expected state and pass it to the `assertState()` 
+method of the test fixture:
 
 <embed-code file="examples/hello/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java" 
             start="@Test @DisplayName(*entity*)" 


### PR DESCRIPTION
This PR addresses #32.

This PR brings theme updates and uses the semantic coloring for code names in texts such as events, commands, projections, rejections, aggregates, or process managers.